### PR TITLE
Fix: Handle empty wildcard requests

### DIFF
--- a/inc/classes/class-srm-redirect.php
+++ b/inc/classes/class-srm-redirect.php
@@ -71,7 +71,7 @@ class SRM_Redirect {
 
 		// get requested path and add a / before it
 		$requested_path = esc_url_raw( apply_filters( 'srm_requested_path', $_SERVER['REQUEST_URI'] ) );
-		$requested_path = untrailingslashit( stripslashes( $requested_path ) );
+		$requested_path = stripslashes( $requested_path );
 
 		/**
 		 * If WordPress resides in a directory that is not the public root, we have to chop
@@ -141,6 +141,17 @@ class SRM_Redirect {
 					if ( ( strrpos( $redirect_to, '*' ) === strlen( $redirect_to ) - 1 ) ) {
 						$redirect_to = rtrim( $redirect_to, '*' ) . ltrim( substr( $requested_path, strlen( $wildcard_base ) ), '/' );
 					}
+				} elseif (
+					// Handle the case of no trailing slashes on redirect from and redirect to, when
+					// requested URL contains the trailingslash.
+					! $matched_path
+					// Check last character in requested URL is a slash.
+					&& strrpos( $normalized_requested_path, '/' ) === strlen( $normalized_requested_path ) - 1
+					// Check that unslashes requested URL exactly matches redirect from.
+					&& untrailingslashit( $normalized_requested_path ) === $redirect_from
+				) {
+					$redirect_to = untrailingslashit( $redirect_to );
+					$matched_path = true;
 				}
 			}
 


### PR DESCRIPTION
Comments in the code suggest the behaviour to allow `/one/` to redirect when Redirect From is `/one/*` and   Redirect To is `/gohere/*` was meant to be, though there was no specific unit test.

This PR adds a unit test, and a fix.

The fix undoes some workaround code related to trailing slashes, and adds specific code to still allow the same behaviour.

Fixes #156.

Before:

<img width="919" alt="screenshot 2018-10-30 at 19 28 17" src="https://user-images.githubusercontent.com/88371/47744795-2209f980-dc7a-11e8-8c2c-9b247a600254.png">


After:

<img width="1314" alt="screenshot 2018-10-30 at 19 29 11" src="https://user-images.githubusercontent.com/88371/47744816-29310780-dc7a-11e8-85bd-f373eadad3a0.png">
